### PR TITLE
repl.sh: Groovy REPL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ subprojects {
         testCompile 'junit:junit:4.11'
     }
 
+    task cp << {
+        println project.sourceSets.test.runtimeClasspath.asPath
+    }
+
     repositories {
         mavenLocal()
         jcenter()

--- a/repl.sh
+++ b/repl.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+cd "`dirname $0`"
+groovysh -cp `./gradlew -q :plog-distro:cp`


### PR DESCRIPTION
Requires a system-wide Groovy install.

Sadly it's virtually impossible to start
an interactive console app from Gradle.

Closes #49.
