### PR TITLE
build.gradle: construct version from git

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,24 @@ idea.module {
     downloadSources = true
 }
 
+ext {
+    gitVersion = new ByteArrayOutputStream().with { out ->
+        exec {
+            commandLine 'git', 'describe', '--tags', '--dirty'
+            standardOutput = out
+        }
+        final full = out.toString().trim()
+        full.startsWith('v') ? full.substring(1) : full
+    }
+}
+
 subprojects {
     apply plugin: 'groovy'
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'bintray'
 
-    version = '4.0.0-ALPHA'
+    version = rootProject.ext.gitVersion
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6


### PR DESCRIPTION
The `ext` trick allows us to memoize for all subprojects.

Example:

```
% find . -name '*.jar'
./gradle/wrapper/gradle-wrapper.jar
./plog-api/build/libs/plog-api-4.0.0-ALPHA-5-g30c49eb.jar
./plog-console/build/libs/plog-console-4.0.0-ALPHA-5-g30c49eb.jar
./plog-distro/build/distributions/plog-distro-4.0.0-ALPHA-5-g30c49eb-shadow.jar
./plog-distro/build/libs/plog-distro-4.0.0-ALPHA-5-g30c49eb.jar
./plog-kafka/build/libs/plog-kafka-4.0.0-ALPHA-5-g30c49eb.jar
./plog-server/build/libs/plog-server-4.0.0-ALPHA-5-g30c49eb.jar
```

Closes #51.
