### PR TITLE
Use separate event loop groups

### DIFF
--- a/plog-server/src/main/java/com/airbnb/plog/PlogServer.java
+++ b/plog-server/src/main/java/com/airbnb/plog/PlogServer.java
@@ -30,8 +30,6 @@ public class PlogServer {
 
     private void run(Config config)
             throws UnknownHostException {
-        final EventLoopGroup group = new NioEventLoopGroup();
-
         final ChannelFutureListener futureListener = new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture channelFuture) throws Exception {
@@ -53,10 +51,10 @@ public class PlogServer {
         final Config tcpDefaults = tcpConfig.getConfig("defaults").withFallback(globalDefaults);
 
         for (final Config cfg : udpConfig.getConfigList("listeners"))
-            new UDPListener(cfg.withFallback(udpDefaults)).start(group).addListener(futureListener);
+            new UDPListener(cfg.withFallback(udpDefaults)).start().addListener(futureListener);
 
         for (final Config cfg : tcpConfig.getConfigList("listeners"))
-            new TCPListener(cfg.withFallback(tcpDefaults)).start(group).addListener(futureListener);
+            new TCPListener(cfg.withFallback(tcpDefaults)).start().addListener(futureListener);
 
         log.info("Started with config {}", config);
     }

--- a/plog-server/src/main/java/com/airbnb/plog/listeners/Listener.java
+++ b/plog-server/src/main/java/com/airbnb/plog/listeners/Listener.java
@@ -7,7 +7,6 @@ import com.airbnb.plog.stats.SimpleStatisticsReporter;
 import com.typesafe.config.Config;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,7 +31,7 @@ public abstract class Listener {
         this.eopHandler = new EndOfPipeline(stats);
     }
 
-    public abstract ChannelFuture start(final EventLoopGroup group);
+    public abstract ChannelFuture start();
 
     void finalizePipeline(ChannelPipeline pipeline)
             throws Exception {

--- a/plog-server/src/main/java/com/airbnb/plog/listeners/TCPListener.java
+++ b/plog-server/src/main/java/com/airbnb/plog/listeners/TCPListener.java
@@ -4,6 +4,7 @@ import com.typesafe.config.Config;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
@@ -18,11 +19,11 @@ public class TCPListener extends Listener {
     }
 
     @Override
-    public ChannelFuture start(final EventLoopGroup group) {
+    public ChannelFuture start() {
         final Config config = getConfig();
 
         return new ServerBootstrap()
-                .group(group)
+                .group(new NioEventLoopGroup())
                 .channel(NioServerSocketChannel.class)
                 .option(ChannelOption.TCP_NODELAY, true)
                 .option(ChannelOption.SO_REUSEADDR, true)

--- a/plog-server/src/main/java/com/airbnb/plog/listeners/UDPListener.java
+++ b/plog-server/src/main/java/com/airbnb/plog/listeners/UDPListener.java
@@ -8,6 +8,7 @@ import com.typesafe.config.Config;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 
@@ -23,7 +24,7 @@ public class UDPListener extends Listener {
     }
 
     @Override
-    public ChannelFuture start(EventLoopGroup group) {
+    public ChannelFuture start() {
         final Config config = getConfig();
 
         final SimpleStatisticsReporter stats = getStats();
@@ -39,7 +40,7 @@ public class UDPListener extends Listener {
                 Executors.newFixedThreadPool(config.getInt("threads"));
 
         return new Bootstrap()
-                .group(group)
+                .group(new NioEventLoopGroup(1))
                 .channel(NioDatagramChannel.class)
                 .option(ChannelOption.SO_REUSEADDR, true)
                 .option(ChannelOption.SO_RCVBUF,

--- a/plog-server/src/test/groovy/com/airbnb/plog/listeners/UDPListenerTest.groovy
+++ b/plog-server/src/test/groovy/com/airbnb/plog/listeners/UDPListenerTest.groovy
@@ -1,7 +1,5 @@
 package com.airbnb.plog.listeners
-
 import com.typesafe.config.ConfigFactory
-import io.netty.channel.nio.NioEventLoopGroup
 
 class UDPListenerTest extends GroovyTestCase {
     final refConfig = ConfigFactory.defaultReference().getConfig('plog')
@@ -10,9 +8,8 @@ class UDPListenerTest extends GroovyTestCase {
 
     private void runTest(Map config, Closure test, String expectation) {
         final compiledConfig = ConfigFactory.parseMap(config).withFallback(defaultUDPConfig)
-        final group = new NioEventLoopGroup()
         final listener = new UDPListener(0, compiledConfig)
-        listener.start(group)
+        listener.start()
 
         final oldOut = System.out
         final newOut = new ByteArrayOutputStream()


### PR DESCRIPTION
By default there's 2 \* processors event loops and they're assigned in a
round-robin fashion within a group, so the current behaviour was very
much OK.

Still, this goes in the direction of clear-cut isolation between
listeners, which we feel strongly about.

Closes #54.
