### PR TITLE
datadog: initial plog4 support work

### DIFF
--- a/third-party/datadog/plog.py
+++ b/third-party/datadog/plog.py
@@ -1,79 +1,133 @@
-from checks import AgentCheck
+# !/usr/bin/env python
+
 from socket import socket, AF_INET, SOCK_DGRAM, error as socketError
 from select import select
 from json import loads
+from numbers import Number
+
+from checks import AgentCheck
+
 
 class PlogCheck(AgentCheck):
-	def check(self, instance):
-		# read config
-		tags = instance.get('tags', [])
-		host = instance.get('host', '127.0.0.1')
-		port = instance.get('port', 23456)
-		prefix = instance.get('prefix', 'plog.')
-		suffix = instance.get('suffix', '')
-		timeout = instance.get('timeout', 3)
-		max_size = instance.get('max_size', 65536)
+    def check(self, instance):
+        # read config
+        tags = instance.get('tags', [])
+        host = instance.get('host', '127.0.0.1')
+        port = instance.get('port', 23456)
+        prefix = instance.get('prefix', 'plog.')
+        suffix = instance.get('suffix', '')
+        timeout = instance.get('timeout', 3)
+        max_size = instance.get('max_size', 65536)
 
-		# create socket, ask for stats
-		sock = socket(AF_INET, SOCK_DGRAM)
-		try:
-			sock.sendto("\0\0statfordatadogplease", (host, port))
+        # create socket, ask for stats
+        sock = socket(AF_INET, SOCK_DGRAM)
+        try:
+            sock.sendto("\0\0statfordatadogplease", (host, port))
 
-			# wait for a reply
-			ready = select([sock], [], [], timeout)
-			if not ready[0]:
-				raise socketError('timeout')
+            # wait for a reply
+            ready = select([sock], [], [], timeout)
+            if not ready[0]:
+                raise socketError('timeout')
 
-			data, addr = sock.recvfrom(max_size)
-			stats = loads(data)
+            data, addr = sock.recvfrom(max_size)
+            stats = loads(data)
+        finally:
+            sock.close()
 
-			def counter(name, val):
-				self.rate(prefix + name + suffix, val, tags=tags)
-			def rate(name, val):
-				self.gauge(prefix + name + suffix, val, tags=tags)
 
-			rate('uptime',
-				stats['uptime'])
-			counter('exceptions',
-				stats['exceptions'])
-			counter('unhandled_objects',
-				stats['unhandled_objects'])
-			counter('udp_simple',
-				stats['udp_simple_messages'])
-			counter('holes.from_dead_port',
-				stats['holes_from_dead_port'])
-			counter('holes.from_new_message',
-				stats['holes_from_new_message'])
-			counter('invalid_checksum',
-				sum(stats['v0_invalid_checksum']))
-			counter('fragments',
-				sum(stats['v0_fragments']))
-			counter('missing_fragments',
-				sum(sum(a) for a in stats['dropped_fragments']))
-			counter('invalid_fragments',
-				sum(sum(a) for a in stats['v0_invalid_fragments']))
+        def rate(name, val):
+            self.rate(prefix + name + suffix, val, tags=tags)
 
-			cache = stats['cache']
-			counter('cache.evictions',
-				cache['evictions'])
-			counter('cache.hits',
-				cache['hits'])
-			counter('cache.miss',
-				cache['misses'])
+        def gauge(name, val):
+            self.gauge(prefix + name + suffix, val, tags=tags)
 
-			kafka = stats['kafka']
-			rate('kafka.messages',
-				kafka['messageRate']['rate'][0])
-			rate('kafka.dropped',
-				kafka['droppedMessageRate']['rate'][0])
-			rate('kafka.bytes',
-				kafka['byteRate']['rate'][0])
-			rate('kafka.resends',
-				kafka['resendRate']['rate'][0])
-			rate('kafka.failed_sends',
-				kafka['failedSendRate']['rate'][0])
-			rate('kafka.serialization_errors',
-				kafka['serializationErrorRate']['rate'][0])
+        gauge('uptime',
+              stats['uptime'])
 
-		finally:
-			sock.close()
+        rate('udp_simple',
+             stats['udp_simple_messages'])
+        rate('udp_invalid_version',
+             stats['udp_invalid_version'])
+        rate('v0_invalid_type',
+             stats['v0_invalid_type'])
+        rate('v0_invalid_multipart_header',
+             stats['v0_invalid_multipart_header'])
+        rate('unknown_command',
+             stats['unknown_command'])
+        rate('v0_commands',
+             stats['v0_commands'])
+        rate('exceptions',
+             stats['exceptions'])
+        rate('unhandled_objects',
+             stats['unhandled_objects'])
+        rate('holes.from_dead_port',
+             stats['holes_from_dead_port'])
+        rate('holes.from_new_message',
+             stats['holes_from_new_message'])
+
+        rate('fragments',
+             sum(stats['v0_fragments']))
+        rate('invalid_checksum',
+             sum(stats['v0_invalid_checksum']))
+
+        rate('invalid_fragments',
+             sum(sum(a) for a in stats['v0_invalid_fragments']))
+        rate('missing_fragments',
+             sum(sum(a) for a in stats['dropped_fragments']))
+
+        defragmenter = stats['defragmenter']
+        rate('defragmenter.evictions',
+             defragmenter['evictions'])
+        rate('defragmenter.hits',
+             defragmenter['hits'])
+        rate('defragmenter.miss',
+             defragmenter['misses'])
+
+        def flatsum(json):
+            if isinstance(json, Number):
+                return json
+            elif isinstance(json, list):
+                return sum(flatsum(o) for o in json)
+            else:
+                return 0
+
+        def feed_handler_metrics(path, json):
+            if isinstance(json, dict):
+                for k in json:
+                    feed_handler_metrics(path + '.' + k, json[k])
+            else:
+                existing = handler_metrics.get(path, 0)
+                handler_metrics[path] = existing + flatsum(json)
+
+        handlers = stats['handlers']
+        handler_metrics = {}
+
+        for handler in handlers:
+            handler_name = handler['name']
+            for metric_name in handler:
+                if metric_name != 'name':
+                    metric_path = handler_name + '.' + metric_name
+                    feed_handler_metrics(metric_path, handler[metric_name])
+
+        for path in handler_metrics:
+            # TODO: rates instead of gauges through YAML config?
+            # We can use rate(my.metric{*}) on Datadog's side for graphing, but alerts
+            # do not support functions _yet_.
+            gauge(path, handler_metrics[path])
+
+
+if __name__ == '__main__':
+    from time import sleep
+    from pprint import PrettyPrinter
+
+    pp = PrettyPrinter(indent=4)
+    check, instances = PlogCheck.from_yaml('./plog.yaml')
+
+    for instance in instances:
+        # Run twice to grab rates, otherwise only gauges appear
+        check.check(instance)
+        sleep(1)
+        check.check(instance)
+        # We don't support events yet
+        # pp.pprint(check.get_events())
+        pp.pprint(check.get_metrics())


### PR DESCRIPTION
- The plugin is now easy to test with:
  
  ```
  $ PYTHONPATH=~/.datadog-agent/agent ./plog.py
  ```
- The logic is now in the order keys are returned by plog.
- Our helper names follow the datadog naming convention.
- The Kafka logic is gone as Kafka is merely a handler now.
- Handlers are fully supported, with the following design:
  - If the same handler appears multiple times in the pipeline,
    we sum-merge stats from all instances.
    Note that handler instances could return different names to
    avoid this, if it ever really makes sense, as naming is dynamic.
  - Nested dictionaries are supported by compiling paths in the form
    'key1.key2.key3.'[...]
  - As we walk the tree, as soon as we see a non-dictionary, we switch
    to "nested summing", so [1,[2,{a:3,b:'c'}] = 1+2+3 = 6.

Closes #58.
