### PR TITLE
build.gradle: versions don't start with v

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,9 @@ ext {
             standardOutput = out
         }
         final full = out.toString().trim()
+
         // 'v1.0' -> '1.0', 'vendetta' -> 'vendetta'
-        full ==~ /v\d/ ? full.substring(1) : full
+        full ==~ /v\d.*/ ? full.substring(1) : full
     }
 }
 


### PR DESCRIPTION
Not sure how I missed it for that long, but it appeared very clearly
in bintray.

v4.0.0-BETA now has a broken version.

Let's fix it for future releases!
