### PR TITLE
reference.conf: remove redundant expire_time

### DIFF
--- a/plog-api/src/main/resources/reference.conf
+++ b/plog-api/src/main/resources/reference.conf
@@ -30,10 +30,6 @@ plog {
         // maximum memory in bytes used to track incoming messages
         max_size = 1048576
 
-        // maximum time to wait after the last message is received
-        // to call it quits for that message
-        expire_time = 10s
-
         // detect holes in message IDs
         // requires message IDs to be continuously incrementing
         detect_holes {


### PR DESCRIPTION
We set it to 1 minute just below.
