### PR TITLE
bump Java version, fix links in README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: java
 
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk7
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ The app settings are read using Typesafe Config.
 
 ### Kafka settings
 
-Please refer to [Kafka's documentation](http://kafka.apache.org/08/configuration.html).
+Please refer to [Kafka's documentation](http://kafka.apache.org/documentation.html#producerconfigs).
 
 ### plog settings
 
-Please refer to [reference.conf](src/main/resources/reference.conf) for all the options and their default values.
+Please refer to [reference.conf](plog-api/src/main/resources/reference.conf) for all the options and their default values.
 
 Note that multiple TCP and UDP ports can be configure and have separate settings, and each has their own sink
 (whether Kafka or standard output).

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ allprojects {
 
   version = rootProject.ext.gitVersion
 
-  sourceCompatibility = 1.6
-  targetCompatibility = 1.6
+  sourceCompatibility = 1.7
+  targetCompatibility = 1.7
 
   group = 'com.airbnb.plog'
 

--- a/plog-kafka/build.gradle
+++ b/plog-kafka/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   compile project(':plog-api')
-  compile('org.apache.kafka:kafka_2.10:0.8.2.0') {
+  compile('org.apache.kafka:kafka_2.10:0.8.2.1') {
     exclude module: 'zookeeper'
     exclude module: 'zkclient'
     exclude module: 'jmxri'


### PR DESCRIPTION
- Links in README.md were broken/outdated.
- Java 6 is way out of life now, time to move on.
