### PR TITLE
Use interface StatisticsReporter instead of SimpleStatisticsReporter class in UDPListener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ build/
 *.pyc
 *.ipr
 *.iws
+*.iml
 application.conf
+.idea

--- a/plog-server/src/main/java/com/airbnb/plog/server/commands/FourLetterCommandHandler.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/commands/FourLetterCommandHandler.java
@@ -1,6 +1,6 @@
 package com.airbnb.plog.server.commands;
 
-import com.airbnb.plog.server.stats.SimpleStatisticsReporter;
+import com.airbnb.plog.server.stats.StatisticsReporter;
 import com.google.common.base.Charsets;
 import com.typesafe.config.Config;
 import io.netty.buffer.ByteBuf;
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public final class FourLetterCommandHandler extends SimpleChannelInboundHandler<FourLetterCommand> {
     private static final byte[] PONG_BYTES = "PONG".getBytes();
-    private final SimpleStatisticsReporter stats;
+    private final StatisticsReporter stats;
     private final Config config;
 
     private DatagramPacket pong(ByteBufAllocator alloc, FourLetterCommand ping) {

--- a/plog-server/src/main/java/com/airbnb/plog/server/listeners/Listener.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/listeners/Listener.java
@@ -4,6 +4,7 @@ import com.airbnb.plog.handlers.Handler;
 import com.airbnb.plog.handlers.HandlerProvider;
 import com.airbnb.plog.server.pipeline.EndOfPipeline;
 import com.airbnb.plog.server.stats.SimpleStatisticsReporter;
+import com.airbnb.plog.server.stats.StatisticsReporter;
 import com.google.common.util.concurrent.AbstractService;
 import com.typesafe.config.Config;
 import io.netty.channel.*;
@@ -19,13 +20,17 @@ abstract class Listener extends AbstractService {
     @Getter
     private final Config config;
     @Getter
-    private final SimpleStatisticsReporter stats;
+    private final StatisticsReporter stats;
     private final EndOfPipeline eopHandler;
     private EventLoopGroup eventLoopGroup = null;
 
     public Listener(Config config) {
+        this(config, new SimpleStatisticsReporter());
+    }
+
+    public Listener(Config config, StatisticsReporter reporter) {
         this.config = config;
-        this.stats = new SimpleStatisticsReporter();
+        this.stats = reporter;
         this.eopHandler = new EndOfPipeline(stats);
     }
 

--- a/plog-server/src/main/java/com/airbnb/plog/server/listeners/UDPListener.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/listeners/UDPListener.java
@@ -3,7 +3,7 @@ package com.airbnb.plog.server.listeners;
 import com.airbnb.plog.server.commands.FourLetterCommandHandler;
 import com.airbnb.plog.server.fragmentation.Defragmenter;
 import com.airbnb.plog.server.pipeline.ProtocolDecoder;
-import com.airbnb.plog.server.stats.SimpleStatisticsReporter;
+import com.airbnb.plog.server.stats.StatisticsReporter;
 import com.typesafe.config.Config;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -29,7 +29,7 @@ public final class UDPListener extends Listener {
     protected StartReturn start() {
         final Config config = getConfig();
 
-        final SimpleStatisticsReporter stats = getStats();
+        final StatisticsReporter stats = getStats();
 
         final ProtocolDecoder protocolDecoder = new ProtocolDecoder(stats);
 

--- a/plog-server/src/main/java/com/airbnb/plog/server/stats/SimpleStatisticsReporter.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/stats/SimpleStatisticsReporter.java
@@ -207,6 +207,7 @@ public final class SimpleStatisticsReporter implements StatisticsReporter {
         throw new NoSuchFieldError();
     }
 
+    @Override
     public synchronized void withDefrag(Defragmenter defragmenter) {
         if (this.defragmenter == null) {
             this.defragmenter = defragmenter;
@@ -215,6 +216,7 @@ public final class SimpleStatisticsReporter implements StatisticsReporter {
         }
     }
 
+    @Override
     public synchronized void appendHandler(Handler handler) {
         this.handlers.add(handler);
     }

--- a/plog-server/src/main/java/com/airbnb/plog/server/stats/StatisticsReporter.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/stats/StatisticsReporter.java
@@ -1,5 +1,8 @@
 package com.airbnb.plog.server.stats;
 
+import com.airbnb.plog.handlers.Handler;
+import com.airbnb.plog.server.fragmentation.Defragmenter;
+
 public interface StatisticsReporter {
     long receivedUdpSimpleMessage();
 
@@ -30,4 +33,10 @@ public interface StatisticsReporter {
     long missingFragmentInDroppedMessage(final int fragmentIndex, final int expectedFragments);
 
     long unhandledObject();
-}
+
+    String toJSON();
+
+    void appendHandler(Handler handler);
+
+    void withDefrag(Defragmenter defragmenter);
+  }


### PR DESCRIPTION
@alexism @nelgau

To allow UDPListener to directly send metrics over TaggedMetricRegistry in jitney-proxy dropwizard application, we have to implement a PlogStatisticsReporter class in jitney-proxy project.  Listener class should have a StatisticsReporter instead of SimpleStatisticsReporter. 

This PR contains all the changes to use interface StatisticsReporter instead of SimpleStatisticsReporter class.  Otherwise, we can use plog's python script to collect metrics.

Another alternative way is to implement a jitney-proxy customized UDP listener class, where we might disable all FourLetterCommands.
