### PR TITLE
set the message key

### DIFF
--- a/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaProvider.java
+++ b/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaProvider.java
@@ -51,7 +51,7 @@ public final class KafkaProvider implements HandlerProvider {
         log.info("Using producer with properties {}", properties);
 
         final ProducerConfig producerConfig = new ProducerConfig(properties);
-        final Producer<byte[], byte[]> producer = new Producer<byte[], byte[]>(producerConfig);
+        final Producer<Integer, byte[]> producer = new Producer<Integer, byte[]>(producerConfig);
 
         EncryptionConfig encryptionConfig = new EncryptionConfig();
         try {


### PR DESCRIPTION
When the message key is not set, Kafka producer sends the message to the same partition for [10mn](https://github.com/apache/kafka/blob/0.8.2/core/src/main/scala/kafka/producer/async/DefaultEventHandler.scala#L65) (configurable with `topic.metadata.refresh.interval.ms`). This might lead to data imbalance between partitions when the ratio number of producers over partitions is low.

In this PR, in order to better distribute the messages over the topic partitions, without limiting the batching efficiency, the same key is used every 1000 messages.

The key is randomly generated every 1000 messages.

@liukai @jun-he @nelgau 