### PR TITLE
publish artifact to bintray after successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
----
 language: java
-
 jdk:
-  - oraclejdk8
-
+- oraclejdk8
 script:
-  - TERM=dumb ./gradlew check --info
-  - TERM=dumb ./gradlew shadowJar --info
-  - python -m py_compile third-party/datadog/plog.py
+- TERM=dumb ./gradlew check --info
+- TERM=dumb ./gradlew shadowJar --info
+- python -m py_compile third-party/datadog/plog.py
+
+# publish artifacts to bintray on tag builds
+# TRAVIS_TAG is a default environment variable that's set if the build is for a tagged commit
+# https://docs.travis-ci.com/user/environment-variables/
+after_success:
+  - >
+      test ! "${TRAVIS_TAG}" &&
+      test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
+      ./gradlew --info bintrayUpload
+
+env:
+  global:
+  - secure: R2LBHRwxi+UFVmmIs5OCl3/GE8x4RVmQJjRCfzTpQPVkYZfPvCo6ADmfkkdBCRibJ8DjHDT+o09hmu7Lb4Cdg5x2Ox6ANEUFE4UWeqQPPwoZ4xmTftRoQomNZyKZKS8qJUl0msWKnDfZFai8kWHE8Ui9LIvbjEZ9b4vHyut7dIc=
+  - secure: Yno0O5gcYW+P8kndZbyxYiFSfPX0M6mm+gef6+vWNlV0wsIOaoYxoq3s1P+VNaZm3XjArWIagIywWxGj3wCKbSH12invIyTqqdIf6yu5cFvC75/nsuoU6x/6YeTzpehIkG4Ddwyyx3ij+HopzIh6kswjYclqyPixoZQoQ5KhLyQ=

--- a/README.md
+++ b/README.md
@@ -26,8 +26,31 @@ While updates may still be made and we welcome feedback, keep in mind we may not
 
         $ ./gradlew shadowJar
 
-- To build source JARs and upload to bintray:
+- To build source JARs and upload to bintray manually:
+  - Create an account on https://bintray.com (you need to create and register your own org first)
+  - Ask an admin (e.g. Alexis Midon @alexism) to invite your newly created user to Airbnb's account
+  - find your bintray API key (Edit Profile > API Key) and set BINTRAY_USER and BINTRAY_KEY environment variables locally. e.g.
+  
+        $ export BINTRAY_USER=<your_user_id>
+        $ export BINTRAY_KEY=<your_api_key>
+        
+  - Tag master with a newer version. Use `git describe --tags` to see the previous version. e.g.
+ 
+        $ git describe --tags --dirty
+        v4.0.0-BETA-36-g21add12
+    
+    This means the previous tag was v4.0.0-BETA, there's been 36 commits since the tagged commit, and HEAD is at 21add12.
+    We use com.github.ben-manes.versions to apply set the build version to the output of 'git describe --tags --dirty'
 
+    To tag a new version, do something like the following
+    
+        $ git tag -a v4.0.1
+        $ git describe --tags --dirty
+        v4.0.1
+        $ git push origin v4.0.1
+ 
+  - Now you are ready to upload to bintray, by running the following command in the root plog directory
+    
         $ ./gradlew build sourcesJar bintrayUpload
 
 ## Configuration

--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,8 @@ allprojects {
   }
 
   bintray {
-    user = project.hasProperty('bintrayUser') ? project.getProperty('bintrayUser') : null
-    key  = project.hasProperty('bintrayKey')  ? project.getProperty('bintrayKey')  : null
+    user = System.env.BINTRAY_USER ? System.env.BINTRAY_USER : project.getProperty('bintrayUser')
+    key  = System.env.BINTRAY_KEY ? System.env.BINTRAY_KEY : project.getProperty('bintrayKey')
 
     publications = ['mavenJava']
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+bintrayUser=fake_user
+bintrayKey=fake_key


### PR DESCRIPTION
- Follow what aerosolve did to set up auto-deploy of tagged builds ( https://github.com/airbnb/aerosolve/commit/67280922b367aced4471894cd434ef540cff400b)

- Update the build section of README.md to include more complete instructions for manually uploading to jfrog

cc @alexism