### PR TITLE
[kafka] Update to kafka 0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/out/
 build/
 /.gradle/
 *.pyc
 *.ipr
 *.iws
 application.conf
+.idea/
+*/out/*

--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,13 @@ allprojects {
 
   version = rootProject.ext.gitVersion
 
-  sourceCompatibility = 1.6
-  targetCompatibility = 1.6
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
 
   group = 'com.airbnb.plog'
 
   ext {
-    nettyVersion = '4.0.24.Final'
+    nettyVersion = '4.1.29.Final'
     slf4jVersion = '1.7.10'
     metricsVersion = '3.0.2'
   }

--- a/config/application.json
+++ b/config/application.json
@@ -1,0 +1,84 @@
+{
+  "plog" : {
+    "server" : {
+      "tcp" : {
+        "listeners" : [
+          {
+            "port" : 23456
+          }
+        ]
+      },
+      "udp" : {
+        "listeners" : [
+          {
+            "port" : 23460,
+            "handlers" : [
+              {
+                "provider" : "com.airbnb.plog.kafka.KafkaProvider",
+                "default_topic" : "scram_events",
+                "producer_config" : {
+                  "compression" : {
+                    "codec" : "snappy"
+                  },
+                  "queue" : {
+                    "enqueue" : {
+                      "timeout" : {
+                        "ms" : 0
+                      }
+                    }
+                  },
+                  "producer" : {
+                    "type" : "async"
+                  },
+                  "bootstrap" : {
+                    "servers" : "localhost:9092"
+                  },
+                  "request" : {
+                    "required" : {
+                      "acks" : 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "port" : 23461,
+            "handlers" : [
+              {
+                "provider" : "com.airbnb.plog.console.ConsoleOutputProvider"
+              },
+              {
+                "provider" : "com.airbnb.plog.kafka.KafkaProvider",
+                "default_topic" : "null",
+                "producer_config" : {
+                  "compression" : {
+                    "codec" : "snappy"
+                  },
+                  "queue" : {
+                    "enqueue" : {
+                      "timeout" : {
+                        "ms" : 0
+                      }
+                    }
+                  },
+                  "producer" : {
+                    "type" : "async"
+                  },
+                  "bootstrap" : {
+                    "servers" : "localhost:9092"
+                  },
+                  "request" : {
+                    "required" : {
+                      "acks" : 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/config/application.json
+++ b/config/application.json
@@ -4,75 +4,49 @@
       "tcp" : {
         "listeners" : [
           {
-            "port" : 23456
+            "port": 23456
           }
         ]
       },
       "udp" : {
         "listeners" : [
           {
-            "port" : 23460,
+            "port": 23461,
             "handlers" : [
-              {
-                "provider" : "com.airbnb.plog.kafka.KafkaProvider",
-                "default_topic" : "scram_events",
-                "producer_config" : {
-                  "compression" : {
-                    "codec" : "snappy"
-                  },
-                  "queue" : {
-                    "enqueue" : {
-                      "timeout" : {
-                        "ms" : 0
-                      }
-                    }
-                  },
-                  "producer" : {
-                    "type" : "async"
-                  },
-                  "bootstrap" : {
-                    "servers" : "localhost:9092"
-                  },
-                  "request" : {
-                    "required" : {
-                      "acks" : 1
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "port" : 23461,
-            "handlers" : [
-              {
-                "provider" : "com.airbnb.plog.console.ConsoleOutputProvider"
-              },
               {
                 "provider" : "com.airbnb.plog.kafka.KafkaProvider",
                 "default_topic" : "null",
                 "producer_config" : {
-                  "compression" : {
-                    "codec" : "snappy"
+                  "partitioner": {
+                    "class": "com.airbnb.plog.kafka.partitioner.FlinkPartitioner",
+                    "maxParallelism": 7200
                   },
-                  "queue" : {
-                    "enqueue" : {
-                      "timeout" : {
-                        "ms" : 0
-                      }
+                  "compression" : {
+                    "type" : "snappy"
+                  },
+                  "linger": {
+                    "ms": 10000
+                  },
+                  "batch" : {
+                    "size" : 131072
+                  },
+                  "send" : {
+                    "buffer" : {
+                      "bytes": 131072
                     }
                   },
-                  "producer" : {
-                    "type" : "async"
+                  "max": {
+                    "block": {
+                      "ms": 0
+                    }
+                  },
+                  "buffer": {
+                    "memory": 75497472
                   },
                   "bootstrap" : {
                     "servers" : "localhost:9092"
                   },
-                  "request" : {
-                    "required" : {
-                      "acks" : 1
-                    }
-                  }
+                  "acks" : 1
                 }
               }
             ]

--- a/plog-kafka/build.gradle
+++ b/plog-kafka/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
   compile project(':plog-api')
   compile(group: 'org.apache.kafka', name: 'kafka-clients', version: '0.9.0.1')
+  testCompile(group: 'org.apache.flink', name: 'flink-streaming-java_2.11', version: '1.6.0')
 }

--- a/plog-kafka/build.gradle
+++ b/plog-kafka/build.gradle
@@ -1,10 +1,4 @@
 dependencies {
   compile project(':plog-api')
-  compile('org.apache.kafka:kafka_2.10:0.8.2.0') {
-    exclude module: 'zookeeper'
-    exclude module: 'zkclient'
-    exclude module: 'jmxri'
-    exclude module: 'jmxtools'
-    exclude module: 'slf4j-simple'
-  }
+  compile(group: 'org.apache.kafka', name: 'kafka-clients', version: '0.9.0.1')
 }

--- a/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaHandler.java
+++ b/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaHandler.java
@@ -4,7 +4,6 @@ import com.airbnb.plog.kafka.KafkaProvider.EncryptionConfig;
 import com.airbnb.plog.Message;
 import com.airbnb.plog.handlers.Handler;
 import com.eclipsesource.json.JsonObject;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -40,7 +39,7 @@ public final class KafkaHandler extends SimpleChannelInboundHandler<Message> imp
 
     private static final ImmutableMap<String, MetricName> SHORTNAME_TO_METRICNAME =
         ImmutableMap.<String, MetricName>builder()
-            // Compatibility with Plog 4.0
+            // Keep some compatibility with Plog 4.0
             .put("message", new MetricName("record-send-rate", "producer-metrics"))
             .put("resend", new MetricName("record-retry-rate", "producer-metrics"))
             .put("failed_send", new MetricName("record-error-rate", "producer-metrics"))
@@ -154,10 +153,11 @@ public final class KafkaHandler extends SimpleChannelInboundHandler<Message> imp
         // Use default kafka naming, include all producer metrics
         for (Map.Entry<MetricName, ? extends Metric> metric : metrics.entrySet()) {
             double value = metric.getValue().value();
+            String name = metric.getKey().name().replace("-", "_");
             if (value > -Double.MAX_VALUE && value < Double.MAX_VALUE) {
-                stats.add(metric.getKey().name(), value);
+                stats.add(name, value);
             } else {
-                stats.add(metric.getKey().name(), 0.0);
+                stats.add(name, 0.0);
             }
         }
 

--- a/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaProvider.java
+++ b/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaProvider.java
@@ -2,6 +2,7 @@ package com.airbnb.plog.kafka;
 
 import com.airbnb.plog.handlers.Handler;
 import com.airbnb.plog.handlers.HandlerProvider;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigValue;
@@ -13,6 +14,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 
 @Slf4j
 public final class KafkaProvider implements HandlerProvider {
@@ -37,6 +39,7 @@ public final class KafkaProvider implements HandlerProvider {
             log.warn("default topic is \"null\"; messages will be discarded unless tagged with kt:");
         }
 
+
         final Properties properties = new Properties();
         for (Map.Entry<String, ConfigValue> kv : config.getConfig("producer_config").entrySet()) {
             properties.put(kv.getKey(), kv.getValue().unwrapped().toString());
@@ -46,9 +49,9 @@ public final class KafkaProvider implements HandlerProvider {
                 InetAddress.getLocalHost().getHostName() + "_" +
                 KafkaProvider.clientId.getAndIncrement();
 
-        properties.put("client.id", clientId);
-        properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        properties.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+        properties.put(ProducerConfig.CLIENT_ID_CONFIG, clientId);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
 
         log.info("Using producer with properties {}", properties);
 

--- a/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaProvider.java
+++ b/plog-kafka/src/main/java/com/airbnb/plog/kafka/KafkaProvider.java
@@ -5,15 +5,14 @@ import com.airbnb.plog.handlers.HandlerProvider;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigValue;
-import kafka.javaapi.producer.Producer;
-import kafka.producer.ProducerConfig;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.InetAddress;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.kafka.common.serialization.StringSerializer;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
 
 @Slf4j
 public final class KafkaProvider implements HandlerProvider {
@@ -48,12 +47,12 @@ public final class KafkaProvider implements HandlerProvider {
                 KafkaProvider.clientId.getAndIncrement();
 
         properties.put("client.id", clientId);
-        properties.put("key.serializer.class", "kafka.serializer.StringEncoder");
+        properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        properties.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
 
         log.info("Using producer with properties {}", properties);
 
-        final ProducerConfig producerConfig = new ProducerConfig(properties);
-        final Producer<String, byte[]> producer = new Producer<String, byte[]>(producerConfig);
+        final KafkaProducer<String, byte[]> producer = new KafkaProducer<String, byte[]>(properties);
 
         EncryptionConfig encryptionConfig = new EncryptionConfig();
         try {

--- a/plog-kafka/src/main/java/com/airbnb/plog/kafka/partitioner/FlinkPartitioner.java
+++ b/plog-kafka/src/main/java/com/airbnb/plog/kafka/partitioner/FlinkPartitioner.java
@@ -1,0 +1,106 @@
+package com.airbnb.plog.kafka.partitioner;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+
+@Slf4j
+public class FlinkPartitioner implements Partitioner {
+  private static final String MAX_PARALLELISM_CONFIG = "partitioner.maxParallelism";
+  private final AtomicInteger counter = new AtomicInteger((new Random()).nextInt());
+  private final AtomicInteger normalCounter = new AtomicInteger(0);
+  private int maxParallelism = 16386;
+
+  private static int toPositive(int number) {
+    return number & 2147483647;
+  }
+
+  public void configure(Map<String, ?> configs) {
+    Object maxParallelism = configs.get(MAX_PARALLELISM_CONFIG);
+    log.warn("Configuration is {}", configs);
+    if (maxParallelism instanceof Number) {
+      this.maxParallelism = ((Number) maxParallelism).intValue();
+    } else if (maxParallelism instanceof String) {
+      try {
+        this.maxParallelism = Integer.parseInt((String) maxParallelism);
+      } catch (NumberFormatException e) {
+        log.error("Failed to parse maxParallelism value {}", maxParallelism);
+      }
+    }
+  }
+
+
+  public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+    List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
+    int numPartitions = partitions.size();
+    int msgCount = normalCounter.incrementAndGet();
+    if (msgCount % 1000 == 0) {
+      log.info("Sent {} messages", msgCount);
+    }
+
+    if (key == null) {
+      int nextValue = this.counter.getAndIncrement();
+      List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
+      if (availablePartitions.size() > 0) {
+        int part = toPositive(nextValue) % availablePartitions.size();
+        return availablePartitions.get(part).partition();
+      } else {
+        return toPositive(nextValue) % numPartitions;
+      }
+    } else {
+      return computePartition(key, numPartitions, maxParallelism);
+    }
+  }
+
+  public void close() {
+  }
+
+  /*
+   * These static functions are derived from the code in KeyGroupRangeAssignment.
+   * https://github.com/apache/flink/blob/8674b69964eae50cad024f2c5caf92a71bf21a09/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
+   * The full dependency into this project results in a significant jar size increase.
+   *
+   * By pulling in only these functions, we keep the distribution size under 10 MB.
+   */
+
+  static int computePartition(Object key, int numPartitions, int maxParallelism) {
+    int group = murmurHash(key.hashCode()) % maxParallelism;
+    return (group * numPartitions) / maxParallelism;
+  }
+
+  static int murmurHash(int code) {
+    code *= 0xcc9e2d51;
+    code = Integer.rotateLeft(code, 15);
+    code *= 0x1b873593;
+
+    code = Integer.rotateLeft(code, 13);
+    code = code * 5 + 0xe6546b64;
+
+    code ^= 4;
+    code = bitMix(code);
+
+    if (code >= 0) {
+      return code;
+    } else if (code != Integer.MIN_VALUE) {
+      return -code;
+    } else {
+      return 0;
+    }
+  }
+
+  static int bitMix(int in) {
+    in ^= in >>> 16;
+    in *= 0x85ebca6b;
+    in ^= in >>> 13;
+    in *= 0xc2b2ae35;
+    in ^= in >>> 16;
+    return in;
+  }
+}

--- a/plog-kafka/src/main/java/com/airbnb/plog/kafka/partitioner/FlinkPartitioner.java
+++ b/plog-kafka/src/main/java/com/airbnb/plog/kafka/partitioner/FlinkPartitioner.java
@@ -19,7 +19,7 @@ public class FlinkPartitioner implements Partitioner {
   private int maxParallelism = 16386;
 
   private static int toPositive(int number) {
-    return number & 2147483647;
+    return number & Integer.MAX_VALUE;
   }
 
   public void configure(Map<String, ?> configs) {

--- a/plog-kafka/src/test/java/com/airbnb/plog/kafka/partitioner/FlinkPartitionerTest.java
+++ b/plog-kafka/src/test/java/com/airbnb/plog/kafka/partitioner/FlinkPartitionerTest.java
@@ -1,0 +1,29 @@
+package com.airbnb.plog.kafka.partitioner;
+
+import java.util.Base64;
+import java.util.Random;
+
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+
+public class FlinkPartitionerTest {
+
+  @Test
+  public void computePartition() {
+    Random random = new Random(42L);
+    byte[] id = new byte[16];
+    int maxParallelism = 10393;
+    int numPartitions = 1983;
+    for (int i = 0; i < 40; i++) {
+      random.nextBytes(id);
+      String encoded = Base64.getEncoder().encodeToString(id);
+      int testPartition = FlinkPartitioner.computePartition(encoded, numPartitions, maxParallelism);
+      int flinkPartition = KeyGroupRangeAssignment.assignKeyToParallelOperator(encoded, maxParallelism, numPartitions);
+
+      assertThat(testPartition, equalTo(flinkPartition));
+    }
+  }
+}

--- a/plog-server/src/main/java/com/airbnb/plog/server/PlogServer.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/PlogServer.java
@@ -2,6 +2,7 @@ package com.airbnb.plog.server;
 
 import com.airbnb.plog.server.listeners.TCPListener;
 import com.airbnb.plog.server.listeners.UDPListener;
+
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;

--- a/plog-server/src/main/java/com/airbnb/plog/server/packetloss/PortHoleDetector.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/packetloss/PortHoleDetector.java
@@ -30,7 +30,7 @@ final class PortHoleDetector {
 
     private void reset(Integer value) {
         if (value != null) {
-             log.info("Resetting {} for {}", this.entries, value);
+            log.info("Resetting {} for {}", this.entries, value);
         }
         this.minSeen = Long.MAX_VALUE;
         this.maxSeen = Long.MIN_VALUE;

--- a/plog-server/src/main/java/com/airbnb/plog/server/packetloss/PortHoleDetector.java
+++ b/plog-server/src/main/java/com/airbnb/plog/server/packetloss/PortHoleDetector.java
@@ -30,7 +30,7 @@ final class PortHoleDetector {
 
     private void reset(Integer value) {
         if (value != null) {
-            log.info("Resetting {} for {}", this.entries, value);
+             log.info("Resetting {} for {}", this.entries, value);
         }
         this.minSeen = Long.MAX_VALUE;
         this.maxSeen = Long.MIN_VALUE;


### PR DESCRIPTION
## Basic version of kafka09 producer for Plog

This implements the very basic form of the kafka 09 producer in plog. It is the minimal form that lets us switch out the Kafka Partitioners in the new producer API. All performance improvements have been delayed for a later release. I wasn't able to get the unix domain sockets to perform as well as I originally anticipated for the use-case.

@luochenUmich 